### PR TITLE
add repo url to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3
 VignetteBuilder: knitr
-URL: https://teunbrand.github.io/gguidance/
+URL: https://teunbrand.github.io/gguidance/,
+    https://github.com/teunbrand/gguidance
 Depends: 
     ggplot2 (>= 3.5.0),
     R (>= 4.1.0)


### PR DESCRIPTION
Hi! I first came to the pkgdown site for the package from social media, but it didn't link to this repo. This PR adds the github url to the DESCRIPTION file so that pkgdown can add the link when building the site.