### PR TITLE
Recognise `key_range_auto()` result in `guide_axis_nested()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # legendry (development version)
 
+* Fixed bug where `guide_axis_nested(key = key_range_auto(...))` produced 
+  duplicated labels (#31)
+
 # legendry 0.1.0
 
 First release.

--- a/R/compose-.R
+++ b/R/compose-.R
@@ -148,8 +148,10 @@ loop_guides <- function(guides, params, method, ...) {
 
 compatible_aes <- function(guides, available_aes, call = caller_env()) {
 
-  available <- lapply(guides, `[[`, name = "available_aes")
+  valid <- !is_each(guides, inherits, what = "GuideNone")
+  available <- lapply(guides[valid], `[[`, name = "available_aes")
   common <- Reduce(any_intersect, available)
+
   if (length(common) < 1) {
     cli::cli_abort(
       "The guides to combine have no shared {.field available aesthetics}.",

--- a/R/guide_axis_nested.R
+++ b/R/guide_axis_nested.R
@@ -106,12 +106,9 @@ guide_axis_nested <- function(
   )
   pad_discrete <- pad_discrete %||% switch(type, fence = 0.5, 0.4)
 
-    labels <- new_guide(
-      available_aes = c("any", "x", "y", "r", "theta"),
-      super = guide_none()
-    )
   if (identical(key, "range_auto") ||
       inherits(key, "key_range_auto_function")) {
+    labels <- guide_none()
   } else {
     labels <- primitive_labels(angle = angle)
   }

--- a/R/guide_axis_nested.R
+++ b/R/guide_axis_nested.R
@@ -106,11 +106,12 @@ guide_axis_nested <- function(
   )
   pad_discrete <- pad_discrete %||% switch(type, fence = 0.5, 0.4)
 
-  if (identical(key, "range_auto")) {
     labels <- new_guide(
       available_aes = c("any", "x", "y", "r", "theta"),
       super = guide_none()
     )
+  if (identical(key, "range_auto") ||
+      inherits(key, "key_range_auto_function")) {
   } else {
     labels <- primitive_labels(angle = angle)
   }

--- a/R/key-range.R
+++ b/R/key-range.R
@@ -86,13 +86,15 @@ key_range_auto <- function(sep = "[^[:alnum:]]+", reverse = FALSE, ...) {
   force(reverse)
   dots <- label_args(...)
   call <- current_call()
-  function(scale, aesthetic = NULL) {
+  fun <- function(scale, aesthetic = NULL) {
     range_from_label(
       scale = scale, aesthetic = aesthetic,
       sep = sep, reverse = reverse, extra_args = dots,
       call = call
     )
   }
+  class(fun) <- union("key_range_auto_function", class(fun))
+  fun
 }
 
 #' @rdname key_range

--- a/tests/testthat/test-guide_axis_nested.R
+++ b/tests/testthat/test-guide_axis_nested.R
@@ -19,6 +19,21 @@ test_that("guide_axis_nested logic works", {
 
 })
 
+test_that("guide_axis_nested recognised `key_range_auto()`", {
+
+  guide <- guide_axis_nested(key = "range_auto")
+  expect_s3_class(guide$params$guides[[3]], "GuideNone")
+
+  guide <- guide_axis_nested(key = key_range_auto(sep = "foobar"))
+  expect_s3_class(guide$params$guides[[3]], "GuideNone")
+
+  guide <- guide_axis_nested(key = key_range_manual(1, 2))
+  expect_s3_class(guide$params$guides[[3]], "PrimitiveLabels")
+
+})
+
+# Visual test -------------------------------------------------------------
+
 test_that("guide_axis_nested looks good as axis", {
 
   base <- ggplot(mpg, aes(interaction(cyl, drv), hwy)) +


### PR DESCRIPTION
This PR aims to fix #31.

Briefly, the problem was that `guide_axis_nested()` was looking for the string "range_auto" and did not recognise the result of `key_range_auto(...)` too.

``` r
devtools::load_all("~/packages/legendry/")
#> ℹ Loading legendry
#> Loading required package: ggplot2

ggplot(mpg, aes(interaction(drv, cyl, sep = " - A - "), hwy)) +
  geom_boxplot() +
  guides(x = guide_axis_nested(key = key_range_auto(sep = " - A - ")))
```

![](https://i.imgur.com/BUusSP4.png)<!-- -->

<sup>Created on 2024-12-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
