### PR TITLE
:bug: Fix `theme_guide(key.width, key.height, key.size)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # legendry (development version)
 
 * Fixed bug hindering `position = "inside"` placement (#42)
+* Fixed bug in `theme_guide(key.size, key.height, key.width)` (#41)
 
 # legendry 0.2.0
 

--- a/R/themes.R
+++ b/R/themes.R
@@ -171,6 +171,9 @@ theme_guide <- function(
     legend.key.spacing = key.spacing,
     legend.key.spacing.x = key.spacing.x,
     legend.key.spacing.y = key.spacing.y,
+    legend.key.size = key.size,
+    legend.key.width = key.width,
+    legend.key.height = key.height,
     legendry.legend.key.margin = key.margin,
 
     legend.frame = frame,

--- a/tests/testthat/test-themes.R
+++ b/tests/testthat/test-themes.R
@@ -12,3 +12,12 @@ test_that("theme elements can be registered", {
   expect_in("legendry.bracket", names(get_element_tree()))
 
 })
+
+test_that("all arguments of theme_guide are used", {
+
+  fmls <- fn_fmls_names(theme_guide)
+  args <- set_names(seq_along(fmls), fmls)
+  theme <- inject(theme_guide(!!!args))
+  expect_setequal(unlist(theme), seq_along(fmls))
+
+})

--- a/tests/testthat/test-themes.R
+++ b/tests/testthat/test-themes.R
@@ -1,0 +1,14 @@
+
+test_that("theme elements can be registered", {
+
+  expect_in("legendry.bracket", names(get_element_tree()))
+
+  ggplot2::reset_theme_settings()
+
+  expect_false("legendry.bracket" %in% names(get_element_tree()))
+
+  register_legendry_elements()
+
+  expect_in("legendry.bracket", names(get_element_tree()))
+
+})


### PR DESCRIPTION
This PR aims to fix #41.

``` r
devtools::load_all("~/packages/legendry/")
#> ℹ Loading legendry
#> Loading required package: ggplot2

thm <- theme_guide(key.width = unit(2, "cm"), 
                   key.height = unit(1, "cm"), 
                   key.spacing.y = unit(1, "cm"))

ggplot(mpg, aes(displ, hwy, colour = drv)) +
  geom_point() +
  guides(colour = guide_legend(theme = thm))
```

![](https://i.imgur.com/8aUdCo8.png)<!-- -->

<sup>Created on 2025-02-15 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
