### PR TITLE
:bug: `<AsIs>` variables in keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Fixed bug in `theme_guide(key.size, key.height, key.width)` (#41)
 * Complete guides based on a crux composition now render the `legend.background` 
   element (#50)
+* A better attempt to honour ggplot2's mechanism for `<AsIs>` variables (#45)
 
 # legendry 0.2.0
 

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -37,7 +37,7 @@ standard_extract_key <- function(scale, aesthetic, key, ...) {
   key <- rename(key, "aesthetic", aesthetic)
   key <- validate_key_types(key)
 
-  if (is.numeric(key$.value)) {
+  if (is.numeric(key$.value) && !inherits(key$.value, "AsIs")) {
     range <- scale$continuous_range %||% scale$get_limits()
     key <- vec_slice(key, is.finite(oob_censor_any(key$.value, range)))
   }

--- a/R/key-range.R
+++ b/R/key-range.R
@@ -162,6 +162,11 @@ range_extract_key <- function(
   key$start <- scale_transform(key$start, scale, map = map, "start")
   key$end   <- scale_transform(key$end,   scale, map = map, "end")
 
+  # Backtransform AsIs variables
+  limits <- scale$continuous_range %||% scale$get_limits()
+  key$start <- descale(key$start, to = limits)
+  key$end   <- descale(key$end,   to = limits)
+
   # Sort starts and ends
   key[c("start", "end")] <- list(
     start = pmin(key$start, key$end),
@@ -183,7 +188,6 @@ range_extract_key <- function(
   }
 
   # Apply out-of-bounds rules
-  limits <- scale$continuous_range %||% scale$get_limits()
   range_oob(key, oob, limits)
 }
 

--- a/R/primitive-segments.R
+++ b/R/primitive-segments.R
@@ -94,6 +94,9 @@ PrimitiveSegments <- ggproto(
   extract_key = function(scale, aesthetic, key, ...) {
     key <- standard_extract_key(scale, aesthetic, key, ...)
     remove <- character()
+    range <- scale$continuous_range %||% scale$get_limits()
+    key$value     <- descale(key$value,     range)
+    key$value_end <- descale(key$value_end, range)
     if (all(c("value", "value_end") %in% names(key))) {
       value <- vec_interleave(key$value, key$value_end)
       remove <- c(remove, c("value", "value_end"))

--- a/R/primitive-segments.R
+++ b/R/primitive-segments.R
@@ -91,36 +91,7 @@ PrimitiveSegments <- ggproto(
     legend   = list(line = "legend.ticks", size = "legend.ticks.length")
   ),
 
-  extract_key = function(scale, aesthetic, key, ...) {
-    key <- standard_extract_key(scale, aesthetic, key, ...)
-    remove <- character()
-    range <- scale$continuous_range %||% scale$get_limits()
-    key$value     <- descale(key$value,     range)
-    key$value_end <- descale(key$value_end, range)
-    if (all(c("value", "value_end") %in% names(key))) {
-      value <- vec_interleave(key$value, key$value_end)
-      remove <- c(remove, c("value", "value_end"))
-    }
-    if (all(c("oppo", "oppo_end") %in% names(key))) {
-      oppo <- vec_interleave(key$oppo, key$oppo_end)
-      remove <- c(remove, c("oppo", "oppo_end"))
-    }
-    key[remove] <- NULL
-    new <- data_frame0(value = value, oppo = oppo)
-    i <- rep(vec_seq_along(key), each = 2)
-    new[names(key)] <- key[i, , drop = FALSE]
-    new$group <- new$group %||% i
-    new$oppo <- rescale(new$oppo, from = range(new$oppo, 0))
-    if (aesthetic == "x") {
-      new <- rename(new, c("value", "oppo"), c("x", "y"))
-    } else if (aesthetic == "y") {
-      new <- rename(new, c("value", "oppo"), c("y", "x"))
-    } else {
-      new <- rename(new, "value", aesthetic)
-      new$.value <- new[[aesthetic]]
-    }
-    new
-  },
+  extract_key = segment_extract_key,
 
   extract_params = primitive_extract_params,
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -152,6 +152,9 @@ scale_transform <- function(x, scale, map = FALSE, arg = caller_arg(x)) {
       "The key {.field {arg}} must be {.emph continuous}, not discrete."
     )
   }
+  if (inherits(x, "AsIs")) {
+    return(x)
+  }
   transform <- scale$get_transformation()
   if (is.null(transform)) {
     if (map) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -302,3 +302,10 @@ extra_args <- function(..., .valid_args = .label_params, call = caller_env()) {
   names(args) <- paste0(".", names(args))
   args
 }
+
+descale <- function(x, to = c(0, 1), from = c(0, 1)) {
+  if (!is.numeric(x) | !inherits(x, "AsIs")) {
+    return(x)
+  }
+  rescale(as.numeric(x), to = to, from = from)
+}

--- a/tests/testthat/test-aaa.R
+++ b/tests/testthat/test-aaa.R
@@ -14,4 +14,7 @@ test_that("standard_extract_key works as intended", {
   key <- standard_extract_key(scale, "x", key = "auto")
   expect_snapshot(key)
 
+  key <- standard_extract_key(scale, "x", key = key_manual(I(c(0.3, 0.7))))
+  expect_equal(key$x, I(c(0.3, 0.7)))
+
 })

--- a/tests/testthat/test-key-range.R
+++ b/tests/testthat/test-key-range.R
@@ -91,6 +91,20 @@ test_that("range_extract_key can censor oob values", {
   expect_equal(test$.label, 'B')
 })
 
+test_that("range_extract_key backtransforms AsIs variables", {
+
+  scale <- scale_x_continuous(limits = c(0, 10))
+
+  key <- key_range_manual(
+    start = I(c(0.1, 0.3, 0.5)),
+    end   = c(1, 3, 5),
+    name  = c("A", "B", "C")
+  )
+
+  test <- range_extract_key(scale, "x", key)
+  expect_equal(test$start, test$end)
+})
+
 test_that("range_from_label can extract ranges", {
 
   values <- c("A 1", "B 1", "C 2")

--- a/tests/testthat/test-key-segment.R
+++ b/tests/testthat/test-key-segment.R
@@ -46,3 +46,17 @@ test_that("key_dendro works as intended", {
   expect_vector(test, ptype, size = 4)
 
 })
+
+test_that("segment_extract_key works as intended", {
+
+  key <- key_segment_manual(value = 1, oppo = 0, value_end = I(0.9), oppo_end = 1)
+
+  sc <- scale_x_continuous(limits = c(0, 10))
+  test <- segment_extract_key(sc, "x", key)
+  expect_equal(test$x, c(1, 9))
+
+  sc <- scale_colour_gradient(limits = c(0, 10))
+  test <- segment_extract_key(sc, "colour", key)
+  expect_equal(test$.value, c(1, 9))
+
+})


### PR DESCRIPTION
This PR aims to fix #45.

Briefly, it attempts to preserve `<AsIs>` variables better. For standard keys, excluding censoring is sufficient to let this work as intended. For other keys, we need to transform AsIs variables from the [0, 1] range back to the limits, as we cannot mix regular and AsIs variables when interleaving.

Reprex based on issue:

``` r
devtools::load_all("~/packages/legendry/")
#> ℹ Loading legendry
#> Loading required package: ggplot2

data.frame(x = 0:1, y = 0:1) |>
  ggplot(aes(x, y)) +
  geom_line() +
  scale_x_continuous(
    limits = c(.51, NA), expand = c(0, 0), oob = scales::oob_keep,
    guide = compose_stack("axis", guide_axis_base(
      key = key_manual(I(.5), label = "I(.5)"),
      theme = theme_guide(
        ticks.length = unit(1.5, "cm"),
        ticks = element_line(arrow = arrow())
      )
    ))
  )
```

![](https://i.imgur.com/bpE48EU.png)<!-- -->

<sup>Created on 2025-02-15 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
