### PR TITLE
:bug: Fix bug in `guide_circles()` with multiple layers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # legendry (development version)
 
+* Fixed bug in `guide_circles()` used for multiple layers (#58)
 * Fixed bug hindering `position = "inside"` placement (#42)
 * Fixed bug in `theme_guide(key.size, key.height, key.width)` (#41)
 * Complete guides based on a crux composition now render the `legend.background` 

--- a/R/guide-circles.R
+++ b/R/guide-circles.R
@@ -133,7 +133,9 @@ GuideCircles <- ggproto(
     params
   },
 
-  get_layer_key = GuideLegend$get_layer_key,
+  process_layers = function(self, params, layers, data = NULL) {
+    GuideLegend$process_layers(params, layers, data)
+  },
 
   build_decor = function(decor, grobs, elements, params) {
 


### PR DESCRIPTION
This PR aims to fix #58.

The issue was that the layer-rejection mechanism of `GuideLegend` wasn't used properly.

``` r
devtools::load_all("~/packages/legendry/")
#> ℹ Loading legendry
#> Loading required package: ggplot2

ggplot(mtcars) +
  aes(x = mpg, y = hp, color = cyl) +
  geom_point(aes(x = mpg, y = hp, fill = cyl, size=hp), shape=21) +
  geom_smooth(aes(x = mpg, y = hp), inherit.aes = FALSE) +
  scale_size(breaks = c(100, 250), guide = "circles")
#> `geom_smooth()` using method = 'loess' and formula = 'y ~ x'
```

![](https://i.imgur.com/J6Yi1Bk.png)<!-- -->

<sup>Created on 2025-02-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
