### PR TITLE
:bug: Standardise `override. aes`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
   element (#50)
 * A better attempt to honour ggplot2's mechanism for `<AsIs>` variables (#45)
 * Better alignment of `compose_stack(side.titles)` (#48)
+* Fixed aesthetic standardisation in `override.aes` arguments (#60)
 
 # legendry 0.2.0
 

--- a/R/guide-circles.R
+++ b/R/guide-circles.R
@@ -96,7 +96,7 @@ guide_circles <- function(
     vjust = vjust,
     text_position = text_position,
     clip_text = clip_text,
-    override.aes = override.aes,
+    override.aes = rename_aes(override.aes),
     position = position,
     direction = direction,
     super = GuideCircles

--- a/R/guide-legend-base.R
+++ b/R/guide-legend-base.R
@@ -100,7 +100,7 @@ guide_legend_base <- function(
     design = design,
     nrow = nrow,
     ncol = ncol,
-    override.aes = override.aes,
+    override.aes = rename_aes(override.aes),
     reverse = reverse,
     theme = theme,
     position = position,

--- a/R/guide-legend-cross.R
+++ b/R/guide-legend-cross.R
@@ -91,7 +91,7 @@ guide_legend_cross <- function(
     key = key,
     title = title,
     dim_order = dim_order,
-    override.aes = override.aes,
+    override.aes = rename_aes(override.aes),
     col_text = col_text,
     reverse = reverse,
     theme = theme,

--- a/R/guide-legend-group.R
+++ b/R/guide-legend-group.R
@@ -77,7 +77,7 @@ guide_legend_group <- function(
     key = key,
     title = title,
     theme = theme,
-    override.aes = override.aes,
+    override.aes = rename_aes(override.aes),
     nrow = nrow,
     ncol = ncol,
     order = order,

--- a/R/utils-ggplot2.R
+++ b/R/utils-ggplot2.R
@@ -244,6 +244,19 @@ polar_bbox <- function(arc, margin = c(0.05, 0.05, 0.05, 0.05),
   list(x = c(bounds[4], bounds[2]), y = c(bounds[3], bounds[1]))
 }
 
+rename_aes <- function(x, arg = caller_arg(x)) {
+  force(arg)
+  names(x) <- standardise_aes_names(names(x))
+  dups <- names(x)[duplicated(names(x))]
+  if (length(dups) > 0L) {
+    cli::cli_warn(
+      "Duplicated aesthetics in {.arg {arg}} after name standardisations: \\
+      {.field {unique(dups)}}."
+    )
+  }
+  x
+}
+
 in_arc <- function(theta, arc) {
   if (abs(diff(arc)) > 2 * pi - sqrt(.Machine$double.eps)) {
     return(rep(TRUE, length(theta)))

--- a/R/utils-ggplot2.R
+++ b/R/utils-ggplot2.R
@@ -250,7 +250,7 @@ rename_aes <- function(x, arg = caller_arg(x)) {
   dups <- names(x)[duplicated(names(x))]
   if (length(dups) > 0L) {
     cli::cli_warn(
-      "Duplicated aesthetics in {.arg {arg}} after name standardisations: \\
+      "Duplicated aesthetics in {.arg {arg}} after name standardisation: \\
       {.field {unique(dups)}}."
     )
   }

--- a/tests/testthat/_snaps/guide-circles.md
+++ b/tests/testthat/_snaps/guide-circles.md
@@ -1,0 +1,4 @@
+# guide_circles handles override.aes properly
+
+    Duplicated aesthetics in `override.aes` after name standardisation: colour.
+

--- a/tests/testthat/test-guide-circles.R
+++ b/tests/testthat/test-guide-circles.R
@@ -64,3 +64,13 @@ test_that("label placement is ok regardless of hjust/vjust", {
     gt
   )
 })
+
+test_that("guide_circles handles override.aes properly", {
+  p <- guide_circles(override.aes = list(color = "blue", pch = 19))
+  expect_equal(p$params$override.aes, list(colour = "blue", shape = 19))
+
+  expect_snapshot_warning(
+    p <- guide_circles(override.aes = list(colour = "black", color = "red"))
+  )
+  expect_equal(p$params$override.aes, list(colour = "black", colour = "red"))
+})


### PR DESCRIPTION
This PR aim to fix #60.

Briefly it copies and uses `ggplot2:::rename_aes()` in the appropriate places.