### PR TITLE
:bug: Fix rescaling issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
     `key_sequence()` and binned scales invoke `key_bins()`.
     * When using a binned key in `gizmo_histogram()`, the default `hist(breaks)`
     argument is populated with the key's breaks.
+* Fix capping issue with non-canonical rescalers in `primitive_line()` (#67)
 
 # legendry 0.2.0
 

--- a/R/primitive-line.R
+++ b/R/primitive-line.R
@@ -105,11 +105,7 @@ PrimitiveLine <- ggproto(
       decor[[opposite]] <- value
     } else {
       value <- scale$oob(decor[[aesthetic]], range = limits)
-      if (is_theta(position)) {
-        decor[[aesthetic]] <- value
-      } else {
-        decor[[aesthetic]] <- scale$rescale(value, limits)
-      }
+      decor[[aesthetic]] <- value
     }
 
     group <- seq_len(ceiling(nrow(decor) / 2))
@@ -138,12 +134,13 @@ PrimitiveLine <- ggproto(
       y <- unit(decor$y, "npc") + unit(cos(theta) * offset, "cm")
     }
     if (!all(c("x", "y") %in% names(decor))) {
+      value <- guide_rescale(decor[[params$aesthetic]], params$limits)
       if (params$position %in% c("left", "right")) {
-        y <- unit(decor[[params$aesthetic]], "npc")
+        y <- unit(value, "npc")
         x <- as.numeric(params$position == "left") |>
           rep(length.out = length(y)) |> unit("npc")
       } else {
-        x <- unit(decor[[params$aesthetic]], "npc")
+        x <- unit(value, "npc")
         y <- as.numeric(params$position == "bottom") |>
           rep(length.out = length(x)) |> unit("npc")
       }


### PR DESCRIPTION
This PR aims to fix #67.

Axis line now spans the length of the colour bar again

``` r
devtools::load_all("~/packages/legendry/")
#> ℹ Loading legendry
#> Loading required package: ggplot2

ggplot(mpg, aes(displ, hwy, colour = cty)) +
  geom_point() +
  scale_colour_gradient2(
    midpoint = 15,
    guide = guide_colbar(vanilla = FALSE)
  )
```

![](https://i.imgur.com/EK97KoM.png)<!-- -->

<sup>Created on 2025-03-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
