### PR TITLE
✨ Unsupress labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # legendry (development version)
 
 * `legend.key.width/height` is no longer ignored in `guide_colbar()` (#81).
+* `compose_sandwich()` and its wrappers now have a `suppress_labels` argument 
+  that controls label rendering (#91).
 
 # legendry 0.2.2
 

--- a/R/compose-sandwich.R
+++ b/R/compose-sandwich.R
@@ -17,6 +17,9 @@
 #' @param text,opposite Guides to use at the `legend.text.position` location
 #'   and on the opposite side of the `middle` guide respectively. Guide
 #'   specification is the same as in the `middle` argument.
+#' @param suppress_labels A `<character>` vector giving any of `"text"` and
+#'   `"opposite"` for the parallel guides. The guide(s) listed here will not
+#'   draw labels if they support a label suppression mechanism.
 #' @inheritParams compose_crux
 #'
 #' @return A `<ComposeSandwich>` guide object.

--- a/R/compose-sandwich.R
+++ b/R/compose-sandwich.R
@@ -104,7 +104,12 @@ ComposeSandwich <- ggproto(
     theme <- apply_theme_defaults(theme, params$theme_defaults)
 
     opposite <- opposite_position(text_position)
-    params$guide_params$opposite$draw_label <- FALSE
+    if ("opposite" %in% params$suppress_labels) {
+      params$guide_params$opposite$draw_label <- FALSE
+    }
+    if ("text" %in% params$suppress_labels) {
+      params$guide_params$text$draw_label <- FALSE
+    }
 
     old <- c("middle", "text", "opposite")
     new <- c("centre", text_position, opposite)

--- a/R/compose-sandwich.R
+++ b/R/compose-sandwich.R
@@ -44,6 +44,7 @@ compose_sandwich <- function(
   text = "none",
   opposite = "none",
   args = list(),
+  suppress_labels = "opposite",
   complete = TRUE,
   theme = NULL,
   theme_defaults = list(),
@@ -64,6 +65,7 @@ compose_sandwich <- function(
     args = args,
     complete = complete,
     reverse = reverse,
+    suppress_labels = suppress_labels,
     available_aes = available_aes,
     order = order,
     theme = theme,
@@ -84,7 +86,7 @@ ComposeSandwich <- ggproto(
   "ComposeSandwich", Compose,
 
   params = c(Compose$params, list(complete = FALSE, theme_defaults = list(),
-                                  reverse = FALSE)),
+                                  reverse = FALSE, suppress_labels = "opposite")),
 
   draw = function(self, theme, position = NULL, direction = NULL,
                   params = self$params) {

--- a/R/guide-colbar.R
+++ b/R/guide-colbar.R
@@ -22,6 +22,9 @@
 #' @param vanilla A `<logical[1]>` whether to have the default style match
 #'   the vanilla `guide_colourbar()` (`TRUE`) or take the theme
 #'   verbatim (`FALSE`).
+#' @param suppress_labels A `<character>` vector giving any of `"first"` and
+#'   `"second"` for the parallel guides. The guide(s) listed here will not
+#'   draw labels if they support a label suppression mechanism.
 #' @inheritParams gizmo_barcap
 #' @inheritParams compose_sandwich
 #'

--- a/R/guide-colbar.R
+++ b/R/guide-colbar.R
@@ -86,6 +86,7 @@ guide_colbar <- function(
   nbin = 15,
   alpha = NA,
   reverse = FALSE,
+  suppress_labels = "second",
   oob = scales::oob_keep,
   theme = NULL,
   vanilla = TRUE,
@@ -99,6 +100,12 @@ guide_colbar <- function(
     oob = oob, theme = theme
   )
 
+  suppress_labels <- recode(
+    suppress_labels,
+    old = c("first", "second"),
+    new = c("text", "opposite")
+  )
+
   defaults <- if (isTRUE(vanilla)) vanilla_colourbar_theme() else NULL
 
   compose_sandwich(
@@ -107,6 +114,7 @@ guide_colbar <- function(
     text = first_guide,
     opposite = second_guide,
     reverse = reverse,
+    suppress_labels = suppress_labels,
     complete = TRUE,
     title = title,
     theme = theme,

--- a/R/guide-colsteps.R
+++ b/R/guide-colsteps.R
@@ -84,6 +84,7 @@ guide_colsteps <- function(
   show = NA,
   alpha = NA,
   reverse = FALSE,
+  suppress_labels = "second",
   oob = scales::oob_keep,
   theme = NULL,
   position = waiver(),
@@ -98,11 +99,18 @@ guide_colsteps <- function(
 
   defaults <- if (isTRUE(vanilla)) vanilla_coloursteps_theme() else NULL
 
+  suppress_labels <- recode(
+    suppress_labels,
+    old = c("first", "second"),
+    new = c("text", "opposite")
+  )
+
   compose_sandwich(
     key = key,
     middle = steps,
     text = first_guide,
     opposite = second_guide,
+    suppress_labels = suppress_labels,
     complete = TRUE,
     title = title,
     theme = theme,

--- a/R/utils.R
+++ b/R/utils.R
@@ -104,11 +104,15 @@ rename <- function(df, old, new) {
   if (is.function(new)) {
     new <- new(old)
   }
-  i <- match(old, names(df))
-  new <- new[!is.na(i)]
-  i <- i[!is.na(i)]
-  names(df)[i] <- new
+  names(df) <- recode(names(df), old, new)
   df
+}
+
+recode <- function(x, old, new) {
+  i <- match(x, old)
+  skip <- is.na(i)
+  x[!skip] <- new[i][!skip]
+  x
 }
 
 .flip_names <-

--- a/man/compose_sandwich.Rd
+++ b/man/compose_sandwich.Rd
@@ -10,6 +10,7 @@ compose_sandwich(
   text = "none",
   opposite = "none",
   args = list(),
+  suppress_labels = "opposite",
   complete = TRUE,
   theme = NULL,
   theme_defaults = list(),
@@ -40,6 +41,10 @@ specification is the same as in the \code{middle} argument.}
 
 \item{args}{A \verb{<list>} of arguments to pass to guides that are given either
 as a function or as a string.}
+
+\item{suppress_labels}{A \verb{<character>} vector giving any of \code{"text"} and
+\code{"opposite"} for the parallel guides. The guide(s) listed here will not
+draw labels if they support a label suppression mechanism.}
 
 \item{complete}{A \verb{<logical[1]>} whether to treat the composition as a
 complete guide. If \code{TRUE}, a title and margin are added to the result.

--- a/man/guide_colbar.Rd
+++ b/man/guide_colbar.Rd
@@ -15,6 +15,7 @@ guide_colbar(
   nbin = 15,
   alpha = NA,
   reverse = FALSE,
+  suppress_labels = "second",
   oob = scales::oob_keep,
   theme = NULL,
   vanilla = TRUE,
@@ -75,6 +76,10 @@ of the bar. Use \code{NA} to preserve the alpha encoded in the colour itself.}
 \item{reverse}{A \verb{<logical[1]>} whether to reverse continuous guides.
 If \code{TRUE}, guides like colour bars are flipped. If \code{FALSE} (default),
 the original order is maintained.}
+
+\item{suppress_labels}{A \verb{<character>} vector giving any of \code{"first"} and
+\code{"second"} for the parallel guides. The guide(s) listed here will not
+draw labels if they support a label suppression mechanism.}
 
 \item{oob}{An out-of-bounds handling function that affects the cap colour.
 Can be one of the following:

--- a/man/guide_colsteps.Rd
+++ b/man/guide_colsteps.Rd
@@ -14,6 +14,7 @@ guide_colsteps(
   show = NA,
   alpha = NA,
   reverse = FALSE,
+  suppress_labels = "second",
   oob = scales::oob_keep,
   theme = NULL,
   position = waiver(),
@@ -72,6 +73,10 @@ of the bar. Use \code{NA} to preserve the alpha encoded in the colour itself.}
 \item{reverse}{A \verb{<logical[1]>} whether to reverse continuous guides.
 If \code{TRUE}, guides like colour bars are flipped. If \code{FALSE} (default),
 the original order is maintained.}
+
+\item{suppress_labels}{A \verb{<character>} vector giving any of \code{"text"} and
+\code{"opposite"} for the parallel guides. The guide(s) listed here will not
+draw labels if they support a label suppression mechanism.}
 
 \item{oob}{An out-of-bounds handling function that affects the cap colour.
 Can be one of the following:


### PR DESCRIPTION
Fixes #91

``` r
devtools::load_all("~/packages/legendry/")
#> ℹ Loading legendry
#> Loading required package: ggplot2

eff <- range(mpg$cty)
kml <- eff / 2.352
kml <- scales::extended_breaks()(kml)
eff <- kml * 2.352

km_per_liter <- guide_axis_base(key = key_manual(aesthetic = eff, label = kml))


ggplot(mpg, aes(displ, hwy, colour = cty)) +
  geom_point() +
  guides(colour = guide_colbar(second_guide = km_per_liter, suppress_labels = ""))
```

![](https://i.imgur.com/NVDCApR.png)<!-- -->

<sup>Created on 2025-08-13 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
