### PR TITLE
:bug: Pre-validate guides in `scale_x/y_dendro()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # legendry (development version)
 
+* `scale_x/y_dendro()` will no longer fail to lookup `guide_axis_dendro()` when
+  legendry is not on the search path (#94).
+
 # legendry 0.2.3
 
 This is a patch release fixing a few bugs.

--- a/R/scale-dendro.R
+++ b/R/scale-dendro.R
@@ -71,6 +71,8 @@ scale_x_dendro <- function(clust, ..., expand = waiver(), guide = "axis_dendro",
 
   args <- list2(...)
   check_dendro_args(args)
+  # Pre-validating guide here in case legendry is not loaded (#94)
+  guide <- validate_guide(guide)
 
   sc <- inject(discrete_scale(
     aesthetics = c(
@@ -100,6 +102,8 @@ scale_y_dendro <- function(clust, ..., expand = waiver(), guide = "axis_dendro",
 
   args <- list2(...)
   check_dendro_args(args)
+  # Pre-validating guide here in case legendry is not loaded (#94)
+  guide <- validate_guide(guide)
 
   sc <- inject(discrete_scale(
     aesthetics = c(


### PR DESCRIPTION
This PR aims to fix #94.

``` r
library(ggplot2)

hc <- hclust(dist(USArrests), "ave")
df <- reshape2::melt(as.matrix(USArrests))

ggplot(df, aes(Var2, Var1, fill = value)) +
  geom_tile() +
  legendry::scale_y_dendro(hc)
```

![](https://i.imgur.com/Njv5Kv6.png)<!-- -->

<sup>Created on 2025-08-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
