### PR TITLE
:bug: Allow `side.titles` with non-position guides

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # legendry (development version)
 
+* `compose_stack(side.titles)` also work in non-position guides (#101)
+
 # legendry 0.2.4
 
 This is a patch release fixing a few bugs.

--- a/R/compose-stack.R
+++ b/R/compose-stack.R
@@ -118,7 +118,8 @@ ComposeStack <- ggproto(
     }
 
     side  <- elements$side_position
-    sides <- vec_slice(params$sides, params$sides$position == params$position)
+    sides <- params$sides %||% get_sides()
+    sides <- vec_slice(sides, sides$position == params$position)
     sides <- vec_slice(sides, sides$side == side)
 
     element <- elements$side_titles
@@ -335,12 +336,17 @@ theta_side_titles <- function(label, elements, params, ranges) {
   )
 }
 
-get_sides <- function(coord, panel_params) {
+get_sides <- function(coord = NULL, panel_params = NULL) {
 
-  x <- panel_params$x.range %||%
-    switch(coord$theta, x = panel_params$theta.range, panel_params$r.range)
-  y <- panel_params$y.range %||%
-    switch(coord$theta, y = panel_params$theta.range, panel_params$r.range)
+  if (is.null(panel_params)) {
+    x <- c(0, 1)
+    y <- c(0, 1)
+  } else {
+    x <- panel_params$x.range %||%
+      switch(coord$theta, x = panel_params$theta.range, panel_params$r.range)
+    y <- panel_params$y.range %||%
+      switch(coord$theta, y = panel_params$theta.range, panel_params$r.range)
+  }
 
   df <- data_frame0(
     position = rep(.trbl, each = 2),
@@ -349,5 +355,8 @@ get_sides <- function(coord, panel_params) {
     y = y[c(2, 2, 2, 1, 1, 1, 2, 1)],
     group = 1:8
   )
+  if (is.null(coord)) {
+    return(df)
+  }
   coord_munch(coord, df, panel_params)
 }

--- a/R/compose-stack.R
+++ b/R/compose-stack.R
@@ -21,6 +21,10 @@
 #'   side of the stack. Set to `NULL` to display no side titles. If `waiver()`,
 #'   an attempt is made to extract the titles from the guides and use these
 #'   as side titles.
+#'
+#'   The `side.titles` are styled using the `legendry.axis.subtitle` theme
+#'   setting. Their placement is controlled via the
+#'   `legendry.axis.subtitle.position` setting.
 #' @param drop An `<integer>` giving the indices of guides that should be
 #'   dropped when a facet requests no labels to be drawn at axes in between
 #'   panels. The default, `NULL`, will drop every guide except the first.

--- a/R/compose-stack.R
+++ b/R/compose-stack.R
@@ -100,14 +100,29 @@ ComposeStack <- ggproto(
     if (!is_theta(params$position)) {
       elements$spacing <- cm(elements$spacing)
     }
+
+    side_position <- elements$side_position
     if (!is.null(params$side_titles)) {
-      elements$side_position <- switch(
+      side_position <- switch(
         params$position,
         top = , bottom = , theta = , theta.sec =
-          setdiff(elements$side_position, c("top", "bottom")),
-        left = , right = setdiff(elements$side_position, c("left", "right"))
+          setdiff(side_position, c("top", "bottom")),
+        left = , right =
+          setdiff(side_position, c("left", "right"))
       )
-      check_argmatch(elements$side_position, .trbl)
+      if (length(side_position) > 1) {
+        if (any(params$aesthetic %in% c("x", "y"))) {
+          side_position <- side_position[1]
+        } else {
+          # When we are a non-position guide, we don't want to interfere
+          # with the title, so we try to avoid placing the side titles there
+          title_position <- calc_element("legend.title.position", theme) %||%
+            switch(params$direction, vertical = "top", horizontal = "left")
+          side_position <- setdiff(side_position, title_position)[1]
+        }
+      }
+      check_argmatch(side_position, .trbl)
+      elements$side_position <- side_position
     }
     elements
   },

--- a/R/themes.R
+++ b/R/themes.R
@@ -220,7 +220,7 @@ register_legendry_elements <- function() {
     legendry.guide.spacing = unit(2.25, "pt"),
     legendry.group.spacing = rel(2),
     legendry.axis.subtitle = element_text(margin = margin(5.5, 5.5, 5.5, 5.5)),
-    legendry.axis.subtitle.position = c("left", "top"),
+    legendry.axis.subtitle.position = c("left", "top", "bottom", "right"),
     element_tree = list(
       legendry.bracket.size = el_def("unit"),
       legendry.bracket = el_def(line, "line"),

--- a/man/compose_stack.Rd
+++ b/man/compose_stack.Rd
@@ -43,7 +43,11 @@ the name specified in \code{\link[ggplot2:labs]{labs()}} as the title.}
 \item{side.titles}{A \verb{<character>} giving labels for titles displayed on the
 side of the stack. Set to \code{NULL} to display no side titles. If \code{waiver()},
 an attempt is made to extract the titles from the guides and use these
-as side titles.}
+as side titles.
+
+The \code{side.titles} are styled using the \code{legendry.axis.subtitle} theme
+setting. Their placement is controlled via the
+\code{legendry.axis.subtitle.position} setting.}
 
 \item{angle}{A specification for the text angle. Compared to setting the \code{angle} argument
 in \code{\link[ggplot2:element]{element_text()}}, this argument uses some

--- a/tests/testthat/_snaps/guide-colbar/colbar-side-titles.svg
+++ b/tests/testthat/_snaps/guide-colbar/colbar-side-titles.svg
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NjU0LjU3fDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='621.78' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NjU0LjU3fDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='621.78' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='32.79,478.94 654.57,478.94 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,377.91 654.57,377.91 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,276.88 654.57,276.88 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,175.85 654.57,175.85 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,74.81 654.57,74.81 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='172.30,545.11 172.30,22.78 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='313.30,545.11 313.30,22.78 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='454.30,545.11 454.30,22.78 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='595.29,545.11 595.29,22.78 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,529.45 654.57,529.45 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,428.42 654.57,428.42 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,327.39 654.57,327.39 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,226.36 654.57,226.36 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,125.33 654.57,125.33 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,24.30 654.57,24.30 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='101.80,545.11 101.80,22.78 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='242.80,545.11 242.80,22.78 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='383.80,545.11 383.80,22.78 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='524.79,545.11 524.79,22.78 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<circle cx='186.40' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='186.40' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='113.08' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='324.58' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='468.40' cy='353.66' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='278.05' cy='365.78' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='468.40' cy='442.57' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='167.65' cy='238.48' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='159.33' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='197.12' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='197.12' cy='371.84' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='349.68' cy='400.13' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='349.68' cy='381.95' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='349.68' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='626.31' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='609.39' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='581.19' cy='434.48' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='71.77' cy='76.83' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='67.54' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='61.06' cy='46.53' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='130.14' cy='297.08' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='409.18' cy='418.32' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='389.44' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='454.30' cy='462.77' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='524.79' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='72.20' cy='179.89' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='130.43' cy='206.15' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='94.90' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='455.71' cy='412.26' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='165.25' cy='333.45' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='385.21' cy='428.42' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='131.41' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='532.48' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='27.86' y='431.45' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='27.86' y='330.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='27.86' y='229.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='27.86' y='128.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='27.86' y='27.33' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<polyline points='30.05,529.45 32.79,529.45 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,428.42 32.79,428.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,327.39 32.79,327.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,226.36 32.79,226.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,125.33 32.79,125.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,24.30 32.79,24.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='101.80,547.85 101.80,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='242.80,547.85 242.80,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='383.80,547.85 383.80,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='524.79,547.85 524.79,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='101.80' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='242.80' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='383.80' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='524.79' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text x='343.68' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<rect x='665.53' y='227.60' width='48.99' height='112.69' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='671.01' y='241.79' style='font-size: 11.00px; font-family: sans;' textLength='13.45px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<polygon points='681.39,334.81 698.67,334.81 698.67,248.41 681.39,248.41 ' style='stroke-width: 0.75; stroke: none; fill: none;' />
+<polyline points='684.84,334.81 681.39,334.81 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='684.84,313.21 681.39,313.21 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='684.84,291.61 681.39,291.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='684.84,270.01 681.39,270.01 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='684.84,248.41 681.39,248.41 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='675.91' y='337.84' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='675.91' y='316.24' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='675.91' y='294.64' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='675.91' y='273.04' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='675.91' y='251.44' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='676.20' y='346.35' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.72px' lengthAdjust='spacingAndGlyphs'>bar</text>
+<polyline points='695.21,334.81 698.67,334.81 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='695.21,313.21 698.67,313.21 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='695.21,291.61 698.67,291.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='695.21,270.01 698.67,270.01 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='695.21,248.41 698.67,248.41 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='704.15' y='337.84' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='704.15' y='316.24' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='704.15' y='294.64' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='704.15' y='273.04' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='704.15' y='251.44' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='703.85' y='346.35' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>foo</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='94.65px' lengthAdjust='spacingAndGlyphs'>colbar side titles</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/guide-colbar/colbar-side-titles.svg
+++ b/tests/testthat/_snaps/guide-colbar/colbar-side-titles.svg
@@ -21,63 +21,45 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzIuNzl8NjU0LjU3fDIyLjc4fDU0NS4xMQ=='>
-    <rect x='32.79' y='22.78' width='621.78' height='522.33' />
+  <clipPath id='cpMzIuNzl8NjY1LjUzfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='632.74' height='522.33' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzIuNzl8NjU0LjU3fDIyLjc4fDU0NS4xMQ==)'>
-<rect x='32.79' y='22.78' width='621.78' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
-<polyline points='32.79,478.94 654.57,478.94 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,377.91 654.57,377.91 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,276.88 654.57,276.88 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,175.85 654.57,175.85 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,74.81 654.57,74.81 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='172.30,545.11 172.30,22.78 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='313.30,545.11 313.30,22.78 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='454.30,545.11 454.30,22.78 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='595.29,545.11 595.29,22.78 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,529.45 654.57,529.45 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,428.42 654.57,428.42 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,327.39 654.57,327.39 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,226.36 654.57,226.36 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,125.33 654.57,125.33 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='32.79,24.30 654.57,24.30 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='101.80,545.11 101.80,22.78 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='242.80,545.11 242.80,22.78 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='383.80,545.11 383.80,22.78 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='524.79,545.11 524.79,22.78 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<circle cx='186.40' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
-<circle cx='186.40' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
-<circle cx='113.08' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='324.58' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
-<circle cx='468.40' cy='353.66' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='278.05' cy='365.78' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
-<circle cx='468.40' cy='442.57' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='167.65' cy='238.48' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='159.33' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='197.12' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
-<circle cx='197.12' cy='371.84' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
-<circle cx='349.68' cy='400.13' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='349.68' cy='381.95' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='349.68' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='626.31' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='609.39' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='581.19' cy='434.48' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='71.77' cy='76.83' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='67.54' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='61.06' cy='46.53' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='130.14' cy='297.08' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='409.18' cy='418.32' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='389.44' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='454.30' cy='462.77' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='524.79' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='72.20' cy='179.89' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='130.43' cy='206.15' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='94.90' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
-<circle cx='455.71' cy='412.26' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='165.25' cy='333.45' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
-<circle cx='385.21' cy='428.42' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
-<circle cx='131.41' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<g clip-path='url(#cpMzIuNzl8NjY1LjUzfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='632.74' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='189.11' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='189.11' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='114.50' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='329.72' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='476.07' cy='353.66' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='282.37' cy='365.78' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='476.07' cy='442.57' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='170.03' cy='238.48' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='161.56' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='200.01' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='200.01' cy='371.84' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='355.26' cy='400.13' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='355.26' cy='381.95' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='355.26' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='636.77' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='619.55' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='590.86' cy='434.48' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='72.46' cy='76.83' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='68.15' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='61.55' cy='46.53' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='131.86' cy='297.08' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='415.81' cy='418.32' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='395.72' cy='424.38' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='461.73' cy='462.77' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='533.47' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='72.89' cy='179.89' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='132.15' cy='206.15' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='95.99' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<circle cx='463.16' cy='412.26' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='167.59' cy='333.45' r='1.95' style='stroke-width: 0.71; stroke: #2B9089; fill: #2B9089;' />
+<circle cx='391.42' cy='428.42' r='1.95' style='stroke-width: 0.71; stroke: #FDE725; fill: #FDE725;' />
+<circle cx='133.15' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #440154; fill: #440154;' />
+<rect x='32.79' y='22.78' width='632.74' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='27.86' y='532.48' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
@@ -92,41 +74,41 @@
 <polyline points='30.05,226.36 32.79,226.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='30.05,125.33 32.79,125.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='30.05,24.30 32.79,24.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='101.80,547.85 101.80,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='242.80,547.85 242.80,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='383.80,547.85 383.80,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='524.79,547.85 524.79,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='101.80' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='242.80' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
-<text x='383.80' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
-<text x='524.79' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
-<text x='343.68' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<polyline points='103.02,547.85 103.02,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='246.50,547.85 246.50,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='389.98,547.85 389.98,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='533.47,547.85 533.47,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='103.02' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='246.50' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='389.98' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='533.47' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text x='349.16' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
-<rect x='665.53' y='227.60' width='48.99' height='112.69' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='671.01' y='241.79' style='font-size: 11.00px; font-family: sans;' textLength='13.45px' lengthAdjust='spacingAndGlyphs'>cyl</text>
-<polygon points='681.39,334.81 698.67,334.81 698.67,248.41 681.39,248.41 ' style='stroke-width: 0.75; stroke: none; fill: none;' />
-<polyline points='684.84,334.81 681.39,334.81 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='684.84,313.21 681.39,313.21 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='684.84,291.61 681.39,291.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='684.84,270.01 681.39,270.01 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='684.84,248.41 681.39,248.41 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<text x='675.91' y='337.84' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='675.91' y='316.24' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='675.91' y='294.64' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='675.91' y='273.04' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
-<text x='675.91' y='251.44' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
-<text x='676.20' y='346.35' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.72px' lengthAdjust='spacingAndGlyphs'>bar</text>
-<polyline points='695.21,334.81 698.67,334.81 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='695.21,313.21 698.67,313.21 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='695.21,291.61 698.67,291.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='695.21,270.01 698.67,270.01 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='695.21,248.41 698.67,248.41 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<text x='704.15' y='337.84' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='704.15' y='316.24' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='704.15' y='294.64' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='704.15' y='273.04' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
-<text x='704.15' y='251.44' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
-<text x='703.85' y='346.35' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>foo</text>
+<rect x='676.49' y='233.08' width='38.03' height='101.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='676.49' y='241.79' style='font-size: 11.00px; font-family: sans;' textLength='13.45px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<polygon points='686.87,334.81 704.15,334.81 704.15,248.41 686.87,248.41 ' style='stroke-width: 0.75; stroke: none; fill: none;' />
+<polyline points='690.32,334.81 686.87,334.81 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='690.32,313.21 686.87,313.21 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='690.32,291.61 686.87,291.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='690.32,270.01 686.87,270.01 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='690.32,248.41 686.87,248.41 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='681.39' y='337.84' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='681.39' y='316.24' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='681.39' y='294.64' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='681.39' y='273.04' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='681.39' y='251.44' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='681.68' y='346.35' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.72px' lengthAdjust='spacingAndGlyphs'>bar</text>
+<polyline points='700.69,334.81 704.15,334.81 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='700.69,313.21 704.15,313.21 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='700.69,291.61 704.15,291.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='700.69,270.01 704.15,270.01 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='700.69,248.41 704.15,248.41 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='709.63' y='337.84' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='709.63' y='316.24' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='709.63' y='294.64' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='709.63' y='273.04' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='709.63' y='251.44' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='709.33' y='346.35' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>foo</text>
 <text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='94.65px' lengthAdjust='spacingAndGlyphs'>colbar side titles</text>
 </g>
 </svg>

--- a/tests/testthat/test-guide-colbar.R
+++ b/tests/testthat/test-guide-colbar.R
@@ -24,3 +24,20 @@ test_that("guide_colbar works in all positions", {
     vdiffr::expect_doppelganger("top position", base + theme(legend.position = "top"))
   })
 })
+
+test_that("guide_colbar can display side titles", {
+
+  p <- ggplot(mtcars, aes(disp, mpg, colour = cyl)) +
+    geom_point() +
+    scale_colour_viridis_c(
+      guide = guide_colbar(
+        suppress_labels = FALSE,
+        first_guide  = compose_stack("axis_base", side.titles = "foo"),
+        second_guide = compose_stack("axis_base", side.titles = "bar")
+      )
+    )
+
+  suppressWarnings({
+    vdiffr::expect_doppelganger("colbar side titles", p)
+  })
+})


### PR DESCRIPTION
``` r
devtools::load_all("~/packages/legendry/")
#> ℹ Loading legendry
#> Loading required package: ggplot2

df <- data.frame(A = letters[1:5], B = 1:5)

ggplot(df, aes(x = A, y = B, fill = B)) +
  geom_col() +
  scale_fill_gradient(
    high = "blue", low = "red",
    labels = letters[1:5]
  ) +
  theme(
    legend.position = "bottom",
    legend.text.position = "top"
  ) +
  guides(
    fill = guide_colbar(
      title = NULL, suppress_labels = FALSE,
      theme = theme(
        legend.title = element_text(
          hjust = .5, margin = margin()
        ),
        legend.text = element_text(
          margin = margin(t = 2, b = 2)
        )
      ),
      first_guide = compose_stack(
        guide_axis_base(),
        side.titles = "Foobar"
      ),
      second_guide = compose_stack(
        guide_axis_base(key = key_manual(1:5)),
        side.titles = "Qux"
      )
    )
  )
```

![](https://i.imgur.com/nuToXrb.png)<!-- -->

<sup>Created on 2025-09-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
