### PR TITLE
:alien: Comply with ggplot2's new titling mechanism

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ URL: https://teunbrand.github.io/legendry/,
     https://github.com/teunbrand/legendry
 BugReports: https://github.com/teunbrand/legendry/issues
 Depends: 
-    ggplot2 (>= 3.5.2),
+    ggplot2 (>= 4.0.0),
     R (>= 4.1.0)
 Imports: 
     cli,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # legendry (development version)
 
+* Updated title mechanism to comply with ggplot2#6200 (#104)
+
 # legendry 0.2.4
 
 This is a patch release fixing a few bugs.

--- a/R/compose-.R
+++ b/R/compose-.R
@@ -74,7 +74,7 @@ Compose <- ggproto(
 
   train = function(self, params = self$params, scale, aesthetic = NULL,
                    title = waiver(), ...) {
-    title <- scale$make_title(params$title %|W|% scale$name %|W|% title)
+    title <- scale$make_title(params$title, scale$name, title)
     position  <- params$position  <- params$position %|W|% NULL
     aesthetic <- params$aesthetic <- aesthetic %||% scale$aesthetics[1]
     check_position(position, inside = TRUE, allow_null = TRUE)

--- a/R/guide-circles.R
+++ b/R/guide-circles.R
@@ -127,7 +127,7 @@ GuideCircles <- ggproto(
   ),
 
   extract_params = function(scale, params, title = waiver(), ...) {
-    params$title    <- scale$make_title(params$title %|W|% scale$name %|W|% title)
+    params$title    <- scale$make_title(params$title, scale$name, title)
     params$position <- params$position %|W|% NULL
     params$limits   <- scale$get_limits()
     params

--- a/R/primitive-title.R
+++ b/R/primitive-title.R
@@ -83,7 +83,7 @@ PrimitiveTitle <- ggproto(
 
   extract_params = function(scale, params, title = waiver(), ...) {
     params$my_title <-
-      scale$make_title(params$my_title %|W|% scale$name %|W|% title)
+      scale$make_title(params$my_title, scale$name, title)
     primitive_extract_params(scale, params, ...)
   },
 


### PR DESCRIPTION
This PR aims to fix #104.

Any formatting function trickle down to the right places.

``` r
devtools::load_all("~/packages/legendry/")
#> ℹ Loading legendry
#> Loading required package: ggplot2

ggplot(mpg, aes(displ, hwy, colour = cty)) +
  geom_point() +
  guides(colour = "colbar") +
  labs(colour = toupper)
```

![](https://i.imgur.com/3qOK24i.png)<!-- -->

<sup>Created on 2025-09-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
